### PR TITLE
Bump connection timeout to 120 seconds

### DIFF
--- a/lib/sendgrid/client.rb
+++ b/lib/sendgrid/client.rb
@@ -252,6 +252,7 @@ module SendGrid
         conn.request :multipart
         conn.request :url_encoded
         conn.adapter adapter
+        conn.options.open_timeout = 120
         conn.headers['User-Agent'] = user_agent
       end
     end


### PR DESCRIPTION
For https://github.com/DripEmail/drip/issues/5179

Try a longer connection timeout to see how it affects the HB issue.