### PR TITLE
Workaround for socket connection timeouts on us-east-1d

### DIFF
--- a/lib/sendgrid/client.rb
+++ b/lib/sendgrid/client.rb
@@ -252,6 +252,7 @@ module SendGrid
         conn.request :multipart
         conn.request :url_encoded
         conn.adapter adapter
+        conn.options.open_timeout = 10
         conn.headers['User-Agent'] = user_agent
       end
     end


### PR DESCRIPTION
This will improve the performance of https://github.com/DripEmail/drip/pull/5214 since almost all connections are made in less than 0.1 seconds.