### PR TITLE
Use newer faraday, ruby 2.4.1

### DIFF
--- a/sendgrid-ruby.gemspec
+++ b/sendgrid-ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'smtpapi', '~> 0.1'
-  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday', '~> 0.13'
   spec.add_dependency 'mimemagic'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
For https://github.com/DripEmail/drip/issues/4195
Needed by https://github.com/DripEmail/drip/pull/6232

Tested with Ruby 2.4.1