### PR TITLE
Renaming our fork to LegacySendGrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SendGrid::Ruby
+# LegacySendGrid::Ruby
 
 This Gem allows you to quickly and easily send emails through SendGrid's Web API using native Ruby.
 
@@ -29,17 +29,17 @@ Create a new client with your SendGrid [API Key](https://app.sendgrid.com/settin
 require 'sendgrid-ruby'
 
 # As a hash
-client = SendGrid::Client.new(api_key: 'YOUR_SENDGRID_APIKEY')
+client = LegacySendGrid::Client.new(api_key: 'YOUR_SENDGRID_APIKEY')
 
 # Or as a block
-client = SendGrid::Client.new do |c|
+client = LegacySendGrid::Client.new do |c|
   c.api_key = 'YOUR_SENDGRID_APIKEY'
 end
 ```
 
 Create a new Mail object and send:
 ```ruby
-mail = SendGrid::Mail.new do |m|
+mail = LegacySendGrid::Mail.new do |m|
   m.to = 'test@sendgrid.com'
   m.from = 'taco@cat.limo'
   m.subject = 'Hello world!'
@@ -55,7 +55,7 @@ puts res.body
 
 You can also create a Mail object with a hash:
 ```ruby
-res = client.send(SendGrid::Mail.new(to: 'example@example.com', from: 'taco@cat.limo', subject: 'Hello world!', text: 'Hi there!', html: '<b>Hi there!</b>'))
+res = client.send(LegacySendGrid::Mail.new(to: 'example@example.com', from: 'taco@cat.limo', subject: 'Hello world!', text: 'Hi there!', html: '<b>Hi there!</b>'))
 puts res.code
 puts res.body
 # 200
@@ -73,7 +73,7 @@ mail.add_attachment('/tmp/report.pdf', 'july_report.pdf')
 
 Inline content can be added to a Mail object with the `add_content` method. The first parameter is the path to the file, the second parameter is the cid to be referenced in the html.
 ```ruby
-mail = SendGrid::Mail.new do |m|
+mail = LegacySendGrid::Mail.new do |m|
   m.to = 'test@sendgrid.com'
   m.from = 'taco@cat.limo'
   m.subject = 'Hello world!'
@@ -112,12 +112,12 @@ params = {
 Params can be set in the usual Ruby ways, including a block or a hash.
 
 ````ruby
-mail = SendGrid::Mail.new do |m|
+mail = LegacySendGrid::Mail.new do |m|
   m.to = 'rbin@sendgrid.com'
   m.from = 'taco@rbin.codes'
 end
 
-client.send(SendGrid::Mail.new(to: 'rbin@sendgrid.com', from: 'taco@cat.limo'))
+client.send(LegacySendGrid::Mail.new(to: 'rbin@sendgrid.com', from: 'taco@cat.limo'))
 ````
 
 #### :to
@@ -125,7 +125,7 @@ client.send(SendGrid::Mail.new(to: 'rbin@sendgrid.com', from: 'taco@cat.limo'))
 Using the **:to** param, we can pass a single email address as a string, or an array of email address strings.
 
 ````ruby
-mail = SendGrid::Mail.new
+mail = LegacySendGrid::Mail.new
 mail.to = 'taco@rbin.codes'
 # or
 mail.to = ['Example Dude <example@email.com>', 'john@email.com']
@@ -136,7 +136,7 @@ mail.to = ['rbin@sendgrid.com', 'taco@cat.limo']
 #### :from
 
 ```ruby
-mail = SendGrid::Mail.new
+mail = LegacySendGrid::Mail.new
 mail.from = 'me@sendgrid.com'
 ```
 
@@ -145,7 +145,7 @@ mail.from = 'me@sendgrid.com'
 As with **:to**, **:cc** can take a single string or an array of strings.
 
 ```ruby
-mail = SendGrid::Mail.new
+mail = LegacySendGrid::Mail.new
 mail.cc = ['robin@sendgrid.com', 'taco@cat.limo']
 ```
 
@@ -154,14 +154,14 @@ mail.cc = ['robin@sendgrid.com', 'taco@cat.limo']
 As with **:to** and **:cc**, **:bcc** can take a single string or an array of strings.
 
 ```ruby
-mail = SendGrid::Mail.new
+mail = LegacySendGrid::Mail.new
 mail.bcc = ['robin@sendgrid.com', 'taco@cat.limo']
 ```
 
 #### :subject
 
 ```ruby
-mail = SendGrid::Mail.new
+mail = LegacySendGrid::Mail.new
 mail.subject = 'This is a subject string'
 ```
 
@@ -171,7 +171,7 @@ mail.subject = 'This is a subject string'
 Using the **:text** param allows us to add plain text to our email body.
 
 ```ruby
-mail = SendGrid::Mail.new
+mail = LegacySendGrid::Mail.new
 mail.text = 'WHATTUP KITTY CAT!?'
 ```
 
@@ -179,7 +179,7 @@ mail.text = 'WHATTUP KITTY CAT!?'
 
 Using the **:html** param allows us to add html content to our email body.
 ```ruby
-mail = SendGrid::Mail.new
+mail = LegacySendGrid::Mail.new
 mail.html = '<html><body>Stuff in here, yo!</body></html>'
 ```
 
@@ -188,7 +188,7 @@ mail.html = '<html><body>Stuff in here, yo!</body></html>'
 The **:template** param allows us to specify a template object for this email to use. The initialized `Template` will automatically be included in the `smtpapi` header and passed to SendGrid.
 
 ```ruby
-template = SendGrid::Template.new('MY_TEMPLATE_ID')
+template = LegacySendGrid::Template.new('MY_TEMPLATE_ID')
 mail.template = template
 ```
 
@@ -204,7 +204,7 @@ users = User.where(email: ['first@gmail.com', 'second@gmail.com'])
 recipients = []
 
 users.each do |user|
-  recipient = SendGrid::Recipient.new(user.email)
+  recipient = LegacySendGrid::Recipient.new(user.email)
   recipient.add_substitution('first_name', user.first_name)
   recipient.add_substitution('city', user.city)
 
@@ -215,13 +215,13 @@ end
 Create a `Template`
 
 ```ruby
-template = SendGrid::Template.new('MY_TEMPLATE_ID')
+template = LegacySendGrid::Template.new('MY_TEMPLATE_ID')
 ```
 
 Create a `Client`
 
 ```ruby
-client = SendGrid::Client.new(api_user: my_user, api_key: my_key)
+client = LegacySendGrid::Client.new(api_user: my_user, api_key: my_key)
 ```
 
 Initialize mail defaults and create the `TemplateMailer`
@@ -234,7 +234,7 @@ mail_defaults = {
   subject: 'Email is great'
 }
 
-mailer = SendGrid::TemplateMailer.new(client, template, recipients)
+mailer = LegacySendGrid::TemplateMailer.new(client, template, recipients)
 ```
 
 Mail it!

--- a/example.rb
+++ b/example.rb
@@ -12,14 +12,14 @@ Dotenv.load
 # sendgrid_password = ENV['SENDGRID_PASSWORD']
 sendgrid_apikey = ENV['SENDGRID_APIKEY']
 
-# client = SendGrid::Client.new(api_user: sendgrid_username, api_key: sendgrid_password)
+# client = LegacySendGrid::Client.new(api_user: sendgrid_username, api_key: sendgrid_password)
 
-client = SendGrid::Client.new do |c|
+client = LegacySendGrid::Client.new do |c|
   # c.api_user = sendgrid_username
   c.api_key = sendgrid_apikey
 end
 
-mail = SendGrid::Mail.new do |m|
+mail = LegacySendGrid::Mail.new do |m|
   m.to = 'to@example.com'
   m.to_name = 'John Doe'
   m.from = 'from@example.com'
@@ -38,4 +38,4 @@ result = client.send(mail)
 puts result.code
 puts result.body
 
-# puts client.send(SendGrid::Mail.new(to: 'elmer.thomas@sendgrid.com', from: 'elmer@thinkingserious.com', subject: 'Hello world!', text: 'Hi there, testing from Ruby!', html: '<b>Hi there, testing from Ruby!</b>'))
+# puts client.send(LegacySendGrid::Mail.new(to: 'elmer.thomas@sendgrid.com', from: 'elmer@thinkingserious.com', subject: 'Hello world!', text: 'Hi there, testing from Ruby!', html: '<b>Hi there, testing from Ruby!</b>'))

--- a/lib/legacy-sendgrid-ruby.rb
+++ b/lib/legacy-sendgrid-ruby.rb
@@ -1,0 +1,8 @@
+require_relative 'legacy_sendgrid/client'
+require_relative 'legacy_sendgrid/exceptions'
+require_relative 'legacy_sendgrid/recipient'
+require_relative 'legacy_sendgrid/template'
+require_relative 'legacy_sendgrid/template_mailer'
+require_relative 'legacy_sendgrid/mail'
+require_relative 'legacy_sendgrid/response'
+require_relative 'legacy_sendgrid/version'

--- a/lib/legacy_sendgrid/client.rb
+++ b/lib/legacy_sendgrid/client.rb
@@ -2,7 +2,7 @@ require 'faraday'
 require 'base64'
 require 'cgi'
 
-module SendGrid
+module LegacySendGrid
   class Client
     attr_accessor :api_user, :api_key, :protocol, :host, :port, :url, :endpoint,
                   :user_agent, :template
@@ -18,7 +18,7 @@ module SendGrid
       self.endpoint         = params.fetch(:endpoint, '/api/mail.send.json')
       self.adapter          = params.fetch(:adapter, adapter)
       self.conn             = params.fetch(:conn, conn)
-      self.user_agent       = params.fetch(:user_agent, "sendgrid/#{SendGrid::VERSION};ruby")
+      self.user_agent       = params.fetch(:user_agent, "sendgrid/#{LegacySendGrid::VERSION};ruby")
       self.raise_exceptions = params.fetch(:raise_exceptions, true)
       yield self if block_given?
     end
@@ -296,10 +296,10 @@ module SendGrid
       res = yield
 
       if raise_exceptions? && res.status != expected_status
-        fail SendGrid::Exception, { code: res.status, headers: res.headers, body: res.body }.to_json
+        fail LegacySendGrid::Exception, { code: res.status, headers: res.headers, body: res.body }.to_json
       end
 
-      SendGrid::Response.new(code: res.status, headers: res.headers, body: res.body)
+      LegacySendGrid::Response.new(code: res.status, headers: res.headers, body: res.body)
     end
   end
 end

--- a/lib/legacy_sendgrid/exceptions.rb
+++ b/lib/legacy_sendgrid/exceptions.rb
@@ -1,4 +1,4 @@
-module SendGrid
+module LegacySendGrid
   class Exception < StandardError
     def initialize(message)
       super(message)

--- a/lib/legacy_sendgrid/mail.rb
+++ b/lib/legacy_sendgrid/mail.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'smtpapi'
 require 'mimemagic'
 
-module SendGrid
+module LegacySendGrid
   class Mail
     attr_accessor :to, :to_name, :from, :from_name, :subject, :text, :html, :cc, :cc_name,
                   :bcc, :bcc_name, :reply_to, :date, :smtpapi, :attachments, :content, :template

--- a/lib/legacy_sendgrid/recipient.rb
+++ b/lib/legacy_sendgrid/recipient.rb
@@ -1,6 +1,6 @@
 require 'smtpapi'
 
-module SendGrid
+module LegacySendGrid
   class Recipient
     class NoAddress < StandardError; end
 

--- a/lib/legacy_sendgrid/response.rb
+++ b/lib/legacy_sendgrid/response.rb
@@ -1,6 +1,6 @@
 require 'json'
 
-module SendGrid
+module LegacySendGrid
   class Response
     attr_reader :code, :headers, :body, :raw_body
 

--- a/lib/legacy_sendgrid/template.rb
+++ b/lib/legacy_sendgrid/template.rb
@@ -1,6 +1,6 @@
 require 'smtpapi'
 
-module SendGrid
+module LegacySendGrid
   class Template
     attr_reader :id, :recipients
 

--- a/lib/legacy_sendgrid/template_mailer.rb
+++ b/lib/legacy_sendgrid/template_mailer.rb
@@ -1,4 +1,4 @@
-module SendGrid
+module LegacySendGrid
   class InvalidClient < StandardError; end
   class InvalidTemplate < StandardError; end
   class InvalidRecipients < StandardError; end
@@ -15,16 +15,16 @@ module SendGrid
     # recipients = []
     #
     # users.each do |user|
-    #   recipient = SendGrid::Recipient.new(user.email)
+    #   recipient = LegacySendGrid::Recipient.new(user.email)
     #   recipient.add_substitution('first_name', user.first_name)
     #   recipient.add_substitution('city', user.city)
     #
     #   recipients << recipient
     # end
     #
-    # template = SendGrid::Template.new('MY_TEMPLATE_ID')
+    # template = LegacySendGrid::Template.new('MY_TEMPLATE_ID')
     #
-    # client = SendGrid::Client.new(api_user: my_user, api_key: my_key)
+    # client = LegacySendGrid::Client.new(api_user: my_user, api_key: my_key)
     #
     # mail_defaults = {
     #   from: 'admin@email.com',
@@ -33,7 +33,7 @@ module SendGrid
     #   subject: 'Email is great',
     # }
     #
-    # mailer = SendGrid::TemplateMailer.new(client, template, recipients)
+    # mailer = LegacySendGrid::TemplateMailer.new(client, template, recipients)
     # mailer.mail(mail_defaults)
     def initialize(client, template, recipients = [])
       @client = client

--- a/lib/legacy_sendgrid/version.rb
+++ b/lib/legacy_sendgrid/version.rb
@@ -1,0 +1,3 @@
+module LegacySendGrid
+  VERSION = '1.1.7'.freeze
+end

--- a/lib/legacy_sendgrid/version.rb
+++ b/lib/legacy_sendgrid/version.rb
@@ -1,3 +1,3 @@
 module LegacySendGrid
-  VERSION = '1.1.7'.freeze
+  VERSION = '1.1.8'.freeze
 end

--- a/lib/sendgrid-ruby.rb
+++ b/lib/sendgrid-ruby.rb
@@ -1,8 +1,0 @@
-require_relative 'sendgrid/client'
-require_relative 'sendgrid/exceptions'
-require_relative 'sendgrid/recipient'
-require_relative 'sendgrid/template'
-require_relative 'sendgrid/template_mailer'
-require_relative 'sendgrid/mail'
-require_relative 'sendgrid/response'
-require_relative 'sendgrid/version'

--- a/lib/sendgrid/version.rb
+++ b/lib/sendgrid/version.rb
@@ -1,3 +1,0 @@
-module SendGrid
-  VERSION = '1.1.7'
-end

--- a/sendgrid-ruby.gemspec
+++ b/sendgrid-ruby.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'sendgrid/version'
+require 'legacy_sendgrid/version'
 
 Gem::Specification.new do |spec|
-  spec.name        = 'sendgrid-ruby'
-  spec.version     = SendGrid::VERSION
+  spec.name        = 'legacy-sendgrid-ruby'
+  spec.version     = LegacySendGrid::VERSION
   spec.authors     = ['Robin Johnson', 'Eddie Zaneski']
   spec.email       = 'community@sendgrid.com'
   spec.summary     = 'Official SendGrid Gem'

--- a/spec/lib/legacy_sendgrid/client_spec.rb
+++ b/spec/lib/legacy_sendgrid/client_spec.rb
@@ -2,29 +2,29 @@ require 'json'
 require 'spec_helper'
 require 'webmock/rspec'
 
-describe 'SendGrid::Client' do
+describe 'LegacySendGrid::Client' do
   it 'should accept a username and password' do
-    expect(SendGrid::Client.new(api_user: 'test', api_key: 'test')).to be_an_instance_of(SendGrid::Client)
+    expect(LegacySendGrid::Client.new(api_user: 'test', api_key: 'test')).to be_an_instance_of(LegacySendGrid::Client)
   end
 
   it 'should accept an api key' do
-    expect(SendGrid::Client.new(api_key: 'sendgrid_123')).to be_an_instance_of(SendGrid::Client)
+    expect(LegacySendGrid::Client.new(api_key: 'sendgrid_123')).to be_an_instance_of(LegacySendGrid::Client)
   end
 
   it 'should build the default url' do
-    expect(SendGrid::Client.new.url).to eq('https://api.sendgrid.com')
+    expect(LegacySendGrid::Client.new.url).to eq('https://api.sendgrid.com')
   end
 
   it 'should build a custom url' do
-    expect(SendGrid::Client.new(port: 3000, host: 'foo.sendgrid.com', protocol: 'tacos').url).to eq('tacos://foo.sendgrid.com:3000')
+    expect(LegacySendGrid::Client.new(port: 3000, host: 'foo.sendgrid.com', protocol: 'tacos').url).to eq('tacos://foo.sendgrid.com:3000')
   end
 
   it 'should use the default endpoint' do
-    expect(SendGrid::Client.new.endpoint).to eq('/api/mail.send.json')
+    expect(LegacySendGrid::Client.new.endpoint).to eq('/api/mail.send.json')
   end
 
   it 'accepts a block' do
-    expect { |b| SendGrid::Client.new(&b) }.to yield_control
+    expect { |b| LegacySendGrid::Client.new(&b) }.to yield_control
   end
 
   describe ':send' do
@@ -32,8 +32,8 @@ describe 'SendGrid::Client' do
       stub_request(:any, 'https://api.sendgrid.com/api/mail.send.json')
         .to_return(body: {message: 'success'}.to_json, status: 200, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
-      mail = SendGrid::Mail.new
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
+      mail = LegacySendGrid::Mail.new
       res = client.send(mail)
       expect(res.code).to eq(200)
     end
@@ -42,8 +42,8 @@ describe 'SendGrid::Client' do
       stub_request(:any, 'https://api.sendgrid.com/api/mail.send.json')
         .to_return(body: {message: 'success'}.to_json, status: 200, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
-      mail = SendGrid::Mail.new
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
+      mail = LegacySendGrid::Mail.new
 
       client.send(mail)
 
@@ -55,8 +55,8 @@ describe 'SendGrid::Client' do
       stub_request(:any, 'https://api.sendgrid.com/api/mail.send.json')
         .to_return(body: {message: 'success'}.to_json, status: 200, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_user: 'foobar', api_key: 'abc123')
-      mail = SendGrid::Mail.new
+      client = LegacySendGrid::Client.new(api_user: 'foobar', api_key: 'abc123')
+      mail = LegacySendGrid::Mail.new
 
       res = client.send(mail)
 
@@ -64,22 +64,22 @@ describe 'SendGrid::Client' do
         .with(body: 'api_key=abc123&api_user=foobar')
     end
 
-    it 'should raise a SendGrid::Exception if status is not 200' do
+    it 'should raise a LegacySendGrid::Exception if status is not 200' do
       stub_request(:any, 'https://api.sendgrid.com/api/mail.send.json')
         .to_return(body: {message: 'error', errors: ['Bad username / password']}.to_json, status: 400, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_user: 'foobar', api_key: 'abc123')
-      mail = SendGrid::Mail.new
+      client = LegacySendGrid::Client.new(api_user: 'foobar', api_key: 'abc123')
+      mail = LegacySendGrid::Mail.new
 
-      expect {client.send(mail)}.to raise_error(SendGrid::Exception)
+      expect {client.send(mail)}.to raise_error(LegacySendGrid::Exception)
     end
 
-    it 'should not raise a SendGrid::Exception if raise_exceptions is disabled' do
+    it 'should not raise a LegacySendGrid::Exception if raise_exceptions is disabled' do
       stub_request(:any, 'https://api.sendgrid.com/api/mail.send.json')
         .to_return(body: {message: 'error', errors: ['Bad username / password']}.to_json, status: 400, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_user: 'foobar', api_key: 'abc123', raise_exceptions: false)
-      mail = SendGrid::Mail.new
+      client = LegacySendGrid::Client.new(api_user: 'foobar', api_key: 'abc123', raise_exceptions: false)
+      mail = LegacySendGrid::Mail.new
 
       expect {client.send(mail)}.not_to raise_error
     end
@@ -109,7 +109,7 @@ describe 'SendGrid::Client' do
       stub_request(:get, endpoint)
         .to_return(body: success_body.to_json, status: 200, headers: headers)
 
-      client = SendGrid::Client.new(api_key: api_key)
+      client = LegacySendGrid::Client.new(api_key: api_key)
 
       res = client.bounces
       expect(res.code).to eq(200)
@@ -120,7 +120,7 @@ describe 'SendGrid::Client' do
       stub_request(:get, endpoint)
         .to_return(body: success_body.to_json, status: 200, headers: headers)
 
-      client = SendGrid::Client.new(api_key: api_key)
+      client = LegacySendGrid::Client.new(api_key: api_key)
       client.bounces
 
       expect(WebMock).to have_requested(:get, endpoint)
@@ -132,7 +132,7 @@ describe 'SendGrid::Client' do
       stub_request(:get, "https://api.sendgrid.com/v3/suppression/bounces").with(headers: { 'Authorization' => 'Basic Zm9vYmFyOmFiYzEyMw==' })
         .to_return(body: success_body.to_json, status: 200, headers: headers)
 
-      client = SendGrid::Client.new(api_user: api_user, api_key: api_key)
+      client = LegacySendGrid::Client.new(api_user: api_user, api_key: api_key)
       client.bounces
     end
 
@@ -140,19 +140,19 @@ describe 'SendGrid::Client' do
       stub_request(:get, endpoint + '?start_time=1443651141&end_time=1443651154')
         .to_return(body: success_body.to_json, status: 200, headers: headers)
 
-      client = SendGrid::Client.new(api_key: api_key)
+      client = LegacySendGrid::Client.new(api_key: api_key)
 
       res = client.bounces(start_time: 1_443_651_141, end_time: 1_443_651_154)
       expect(res.code).to eq(200)
     end
 
-    it 'should raise a SendGrid::Exception if status is not 200' do
+    it 'should raise a LegacySendGrid::Exception if status is not 200' do
       stub_request(:get, endpoint)
         .to_return(body: {message: 'error', errors: ['Bad username / password']}.to_json, status: 400, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: api_key)
+      client = LegacySendGrid::Client.new(api_key: api_key)
 
-      expect { client.bounces }.to raise_error(SendGrid::Exception)
+      expect { client.bounces }.to raise_error(LegacySendGrid::Exception)
     end
   end
 
@@ -170,7 +170,7 @@ describe 'SendGrid::Client' do
       stub_request(:delete, endpoint)
         .to_return(status: 204, headers: headers)
 
-      client = SendGrid::Client.new(api_key: api_key)
+      client = LegacySendGrid::Client.new(api_key: api_key)
 
       res = client.delete_bounce(email)
       expect(res.code).to eq(204)
@@ -180,7 +180,7 @@ describe 'SendGrid::Client' do
       stub_request(:delete, endpoint)
         .to_return(status: 204, headers: headers)
 
-      client = SendGrid::Client.new(api_key: api_key)
+      client = LegacySendGrid::Client.new(api_key: api_key)
       client.delete_bounce(email)
 
       expect(WebMock).to have_requested(:delete, endpoint)
@@ -192,17 +192,17 @@ describe 'SendGrid::Client' do
       stub_request(:delete, "https://api.sendgrid.com/v3/suppression/bounces/#{CGI.escape email}").with(headers: { 'Authorization' => 'Basic Zm9vYmFyOmFiYzEyMw==' })
         .to_return(status: 204, headers: headers)
 
-      client = SendGrid::Client.new(api_user: api_user, api_key: api_key)
+      client = LegacySendGrid::Client.new(api_user: api_user, api_key: api_key)
       client.delete_bounce(email)
     end
 
-    it 'should raise a SendGrid::Exception if status is not 204' do
+    it 'should raise a LegacySendGrid::Exception if status is not 204' do
       stub_request(:delete, endpoint)
         .to_return(body: {message: 'error', errors: ['Bad username / password']}.to_json, status: 400, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: api_key)
+      client = LegacySendGrid::Client.new(api_key: api_key)
 
-      expect { client.delete_bounce(email) }.to raise_error(SendGrid::Exception)
+      expect { client.delete_bounce(email) }.to raise_error(LegacySendGrid::Exception)
     end
   end
 
@@ -260,7 +260,7 @@ describe 'SendGrid::Client' do
       stub_request(:get, "https://api.sendgrid.com/v3/whitelabel/domains?username=#{username}")
         .to_return(body: success_body, status: 200, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
       res = client.whitelabel_domains(username: username)
       expect(res.code).to eq(200)
     end
@@ -318,7 +318,7 @@ describe 'SendGrid::Client' do
       stub_request(:post, 'https://api.sendgrid.com/v3/whitelabel/domains')
         .to_return(body: success_body, status: 201, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
       res = client.create_whitelabel_domain(domain: "example.com")
       expect(res.code).to eq(201)
     end
@@ -358,7 +358,7 @@ describe 'SendGrid::Client' do
       stub_request(:post, "https://api.sendgrid.com/v3/whitelabel/domains/#{domain_id}/validate")
         .to_return(body: success_body, status: 200, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
       res = client.validate_whitelabel_domain(domain_id)
       expect(res.code).to eq(200)
     end
@@ -371,7 +371,7 @@ describe 'SendGrid::Client' do
       stub_request(:delete, "https://api.sendgrid.com/v3/whitelabel/domains/#{domain_id}")
         .to_return(status: 204, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
       res = client.delete_whitelabel_domain(domain_id)
       expect(res.code).to eq(204)
     end
@@ -392,7 +392,7 @@ describe 'SendGrid::Client' do
       stub_request(:get, 'https://api.sendgrid.com/v3/scopes')
         .to_return(body: success_body, status: 200, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
 
       res = client.scopes
       expect(res.code).to eq(200)
@@ -415,7 +415,7 @@ describe 'SendGrid::Client' do
       stub_request(:get, 'https://api.sendgrid.com/v3/api_keys')
         .to_return(body: success_body, status: 200, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
 
       res = client.api_keys
       expect(res.code).to eq(200)
@@ -442,7 +442,7 @@ describe 'SendGrid::Client' do
       stub_request(:post, 'https://api.sendgrid.com/v3/api_keys')
         .to_return(body: success_body, status: 201, headers: {'X-TEST' => 'yes'})
 
-      client = SendGrid::Client.new(api_key: 'abc123')
+      client = LegacySendGrid::Client.new(api_key: 'abc123')
 
       res = client.create_api_key({
         name: "My API Key",
@@ -475,7 +475,7 @@ describe 'SendGrid::Client' do
         stub_request(:post, 'https://api.sendgrid.com/v3/subusers')
           .to_return(body: success_body, status: 201, headers: {'X-TEST' => 'yes'})
 
-        client = SendGrid::Client.new(api_key: 'abc123')
+        client = LegacySendGrid::Client.new(api_key: 'abc123')
 
         res = client.create_subuser({
           username: "John@example.com",
@@ -500,7 +500,7 @@ describe 'SendGrid::Client' do
         stub_request(:post, 'https://api.sendgrid.com/api/filter.setup.json')
           .to_return(body: success_body, status: 200, headers: {'X-TEST' => 'yes'})
 
-        client = SendGrid::Client.new(api_key: 'abc123')
+        client = LegacySendGrid::Client.new(api_key: 'abc123')
 
         res = client.update_filter_settings({
           name: "eventnotify"

--- a/spec/lib/legacy_sendgrid/mail_spec.rb
+++ b/spec/lib/legacy_sendgrid/mail_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe 'SendGrid::Mail' do
+describe 'LegacySendGrid::Mail' do
   before(:each) do
-    @mail = SendGrid::Mail.new
+    @mail = LegacySendGrid::Mail.new
   end
 
   it 'should create an instance' do
-    expect(SendGrid::Mail.new).to be_an_instance_of(SendGrid::Mail)
+    expect(LegacySendGrid::Mail.new).to be_an_instance_of(LegacySendGrid::Mail)
   end
 
   describe 'add_to_name' do
@@ -127,7 +127,7 @@ describe 'SendGrid::Mail' do
     end
 
     context 'a template has been set' do
-      let(:template) { SendGrid::Template.new(anything) }
+      let(:template) { LegacySendGrid::Template.new(anything) }
 
       it 'adds the template to the smtpapi header' do
         expect(@mail.template).to receive(:add_to_smtpapi).with(@mail.smtpapi)
@@ -141,7 +141,7 @@ describe 'SendGrid::Mail' do
       let(:template) { nil }
 
       it 'does not add anything to the smtpapi header' do
-        expect_any_instance_of(SendGrid::Template).to_not receive(:add_to_smtpapi)
+        expect_any_instance_of(LegacySendGrid::Template).to_not receive(:add_to_smtpapi)
         expect(@mail.smtpapi).to receive(:to_json)
 
         @mail.to_h

--- a/spec/lib/legacy_sendgrid/recipient_spec.rb
+++ b/spec/lib/legacy_sendgrid/recipient_spec.rb
@@ -1,6 +1,6 @@
-require_relative '../../../lib/sendgrid/recipient'
+require_relative '../../../lib/legacy_sendgrid/recipient'
 
-module SendGrid
+module LegacySendGrid
   describe Recipient do
     subject { described_class.new(anything) }
 

--- a/spec/lib/legacy_sendgrid/template_mailer_spec.rb
+++ b/spec/lib/legacy_sendgrid/template_mailer_spec.rb
@@ -1,6 +1,6 @@
-require_relative '../../../lib/sendgrid/template_mailer'
+require_relative '../../../lib/legacy_sendgrid/template_mailer'
 
-module SendGrid
+module LegacySendGrid
   describe TemplateMailer do
     let(:client) { anything }
     let(:template) { Template.new(anything) }

--- a/spec/lib/legacy_sendgrid/template_spec.rb
+++ b/spec/lib/legacy_sendgrid/template_spec.rb
@@ -1,6 +1,6 @@
-require_relative '../../../lib/sendgrid/template'
+require_relative '../../../lib/legacy_sendgrid/template'
 
-module SendGrid
+module LegacySendGrid
   describe Template do
     let(:id) { anything }
     subject { described_class.new(id) }

--- a/spec/lib/legacy_sendgrid_spec.rb
+++ b/spec/lib/legacy_sendgrid_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe 'LegacySendGrid' do
   it 'should have a version' do
-    expect(LegacySendGrid::VERSION).to eq('1.1.7')
+    expect(LegacySendGrid::VERSION).to eq('1.1.8')
   end
 end

--- a/spec/lib/legacy_sendgrid_spec.rb
+++ b/spec/lib/legacy_sendgrid_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'LegacySendGrid' do
+  it 'should have a version' do
+    expect(LegacySendGrid::VERSION).to eq('1.1.7')
+  end
+end

--- a/spec/lib/sendgrid_spec.rb
+++ b/spec/lib/sendgrid_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-describe 'SendGrid' do
-  it 'should have a version' do
-    expect(SendGrid::VERSION).to eq('1.1.6')
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,1 @@
-require_relative '../lib/sendgrid-ruby'
+require_relative '../lib/legacy-sendgrid-ruby'


### PR DESCRIPTION
We are already running this code in production. I want to merge it to base branch in order to add some clarity as part of ruby upgrade process.